### PR TITLE
[codex] test: add seam coverage and truthful tooling

### DIFF
--- a/docs/maintainer-compatibility.md
+++ b/docs/maintainer-compatibility.md
@@ -32,6 +32,17 @@ This plugin has a small public surface but a lot of behavior hangs off it. Treat
 
 Run this checklist after any change that touches plugin bootstrap, walker behavior, ACF integration, or styles.
 
+## Validation Path
+
+Use this validation path for routine maintenance and refactor slices:
+
+1. Run the pure-PHP seam tests with `npm test`.
+2. Lint PHP with `npm run lint:php`.
+3. Rebuild Sass with `npm run build` when `src/sass/` changes.
+4. Run the manual WordPress checks below for admin UI, ACF-backed settings, and front-end walker behavior.
+
+The repo currently has no supported `src/js/` build surface. The Gulp workflow should be treated as Sass-only unless real JavaScript sources are added back to the project.
+
 ### Setup
 
 1. Activate the plugin in WordPress.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,17 +1,8 @@
 var gulp = require('gulp');
-var browserify = require('browserify');
-var sass = require('gulp-sass');
-var prefix = require('gulp-autoprefixer');
-var source = require('vinyl-source-stream');
-var buffer = require('vinyl-buffer');
-var es = require('event-stream');
-var rename = require('gulp-rename');
-var uglify = require('gulp-uglify');
+var sass = require('gulp-sass')(require('sass'));
+var autoprefixer = require('gulp-autoprefixer');
+var prefix = autoprefixer.default || autoprefixer;
 var sourcemaps = require('gulp-sourcemaps');
-var cssnano = require('gulp-cssnano');
-var cache = require('gulp-cache');
-var del = require('del');
-var runSequence = require('run-sequence');
 var gutil = require('gulp-util');
 
 
@@ -35,64 +26,11 @@ gulp.task('sass', function () {
         .pipe(gulp.dest('dist/css')); // Outputs it in the css folder
 });
 
-// Compile JavaScript
-gulp.task('js', function() {
-
-    var sourcePath = 'src/js/';
-
-    var files = [
-        'resources.js',
-    ];
-
-    var tasks = files.map(function(entry) {
-        return browserify({ entries: [sourcePath + entry], debug: true })
-            .bundle()
-            .pipe(source(entry))
-            .pipe(rename({
-                extname: '.min.js'
-            }))
-            .pipe(buffer())
-            .pipe(sourcemaps.init({loadMaps: true}))
-            // Add transformation tasks to the pipeline here.
-            .pipe(uglify())
-            .on('error', gutil.log)
-            .pipe(sourcemaps.write('./'))
-            .pipe(gulp.dest('dist/js/'));
-    });
-
-    return es.merge.apply(null, tasks);
-});
-
 // Watchers
 gulp.task('watch', function () {
-    gulp.watch('src/js/**/*.js', gulp.series('js'));
     gulp.watch('src/sass/**/*.scss', gulp.series('sass'));
 });
 
-// Optimization Tasks
-// ------------------
+gulp.task('build', gulp.series('sass'));
 
-// Cleaning
-gulp.task('clean', function () {
-    return del.sync('dist').then(function (cb) {
-        return cache.clearAll(cb);
-    });
-});
-
-// Build Sequences
-// ---------------
-
-gulp.task('default', function (callback) {
-    runSequence(['js', 'sass'], 'watch',
-        callback
-    )
-});
-
-gulp.task('build', function (callback) {
-    runSequence(
-        'clean:dist',
-        'js',
-        'sass',
-        callback
-    )
-});
+gulp.task('default', gulp.series('sass', 'watch'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "gulp-uglify": "^3.0.2",
         "gulp-util": "^1.0.0",
         "run-sequence": "^2.2.1",
+        "sass": "^1.98.0",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0"
       }
@@ -136,6 +137,330 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -1820,6 +2145,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -3381,6 +3717,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -4161,6 +4504,14 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
@@ -6277,6 +6628,57 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sass": {
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+      "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/sax": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "kmdg-menu-elements.php",
   "scripts": {
     "start": "gulp watch",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "watch": "gulp watch",
+    "sass": "gulp sass",
+    "build": "gulp build",
+    "lint:php": "php -l kmdg-menu-elements.php && find classes -name '*.php' -print0 | xargs -0 -n1 php -l",
+    "test": "php tests/run.php"
   },
   "author": "Jake Finley",
   "license": "GPL-3.0",
@@ -24,6 +28,7 @@
     "gulp-uglify": "^3.0.2",
     "gulp-util": "^1.0.0",
     "run-sequence": "^2.2.1",
+    "sass": "^1.98.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,7 +85,7 @@ function menu_elements_test_assert_throws(callable $callback, $expectedClass, $e
 }
 
 if (!function_exists('apply_filters')) {
-    function apply_filters($tag, $value)
+    function apply_filters($tag, $value, ...$args)
     {
         return $value;
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,120 @@
+<?php
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+class MenuElementsTestFailure extends \RuntimeException
+{
+}
+
+$GLOBALS['menu_elements_test_assertions'] = 0;
+
+function menu_elements_test_increment_assertions()
+{
+    $GLOBALS['menu_elements_test_assertions']++;
+}
+
+function menu_elements_test_export($value)
+{
+    return var_export($value, true);
+}
+
+function menu_elements_test_fail($message)
+{
+    throw new MenuElementsTestFailure($message);
+}
+
+function menu_elements_test_assert_same($expected, $actual, $message = '')
+{
+    menu_elements_test_increment_assertions();
+
+    if ($expected !== $actual) {
+        $details = 'Expected ' . menu_elements_test_export($expected) . ' but got ' . menu_elements_test_export($actual) . '.';
+        menu_elements_test_fail(trim($message . ' ' . $details));
+    }
+}
+
+function menu_elements_test_assert_true($condition, $message = '')
+{
+    menu_elements_test_increment_assertions();
+
+    if ($condition !== true) {
+        menu_elements_test_fail($message !== '' ? $message : 'Expected condition to be true.');
+    }
+}
+
+function menu_elements_test_assert_contains($needle, $haystack, $message = '')
+{
+    menu_elements_test_increment_assertions();
+
+    if (strpos($haystack, $needle) === false) {
+        $details = 'Did not find ' . menu_elements_test_export($needle) . ' in ' . menu_elements_test_export($haystack) . '.';
+        menu_elements_test_fail(trim($message . ' ' . $details));
+    }
+}
+
+function menu_elements_test_assert_instance_of($expectedClass, $value, $message = '')
+{
+    menu_elements_test_increment_assertions();
+
+    if (!($value instanceof $expectedClass)) {
+        $actualClass = is_object($value) ? get_class($value) : gettype($value);
+        $details = 'Expected instance of ' . $expectedClass . ' but got ' . $actualClass . '.';
+        menu_elements_test_fail(trim($message . ' ' . $details));
+    }
+}
+
+function menu_elements_test_assert_throws(callable $callback, $expectedClass, $expectedMessagePart = '')
+{
+    menu_elements_test_increment_assertions();
+
+    try {
+        $callback();
+    } catch (\Throwable $throwable) {
+        if (!($throwable instanceof $expectedClass)) {
+            menu_elements_test_fail('Expected exception ' . $expectedClass . ' but got ' . get_class($throwable) . '.');
+        }
+
+        if ($expectedMessagePart !== '' && strpos($throwable->getMessage(), $expectedMessagePart) === false) {
+            menu_elements_test_fail('Expected exception message to contain ' . menu_elements_test_export($expectedMessagePart) . ' but got ' . menu_elements_test_export($throwable->getMessage()) . '.');
+        }
+
+        return;
+    }
+
+    menu_elements_test_fail('Expected exception ' . $expectedClass . ' to be thrown.');
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value)
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($field, $item)
+    {
+        return isset($item->$field) ? $item->$field : null;
+    }
+}
+
+if (!function_exists('get_the_title')) {
+    function get_the_title($item)
+    {
+        return isset($item->title) ? $item->title : '';
+    }
+}
+
+if (!function_exists('sanitize_html_class')) {
+    function sanitize_html_class($class)
+    {
+        return preg_replace('/[^A-Za-z0-9_-]/', '', (string) $class);
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,133 @@
+<?php
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/../aesir/framework/v1/includes/Exceptions/AesirException.php';
+require __DIR__ . '/../classes/MenuElementDefinition.php';
+require __DIR__ . '/../classes/MenuElementRegistry.php';
+require __DIR__ . '/../classes/MenuElementFieldResolver.php';
+require __DIR__ . '/../classes/MenuElementRenderer.php';
+
+$tests = [];
+
+$tests['registry exposes definitions and prototype menu items'] = function () {
+    $registry = new \KMDG\MenuElements\MenuElementRegistry();
+
+    $registry->registerLegacy('Column', 'column', function () {
+        return '';
+    });
+
+    menu_elements_test_assert_same(['column'], $registry->getTypes());
+    menu_elements_test_assert_same('Column', $registry->getTypeLabel('column'));
+    menu_elements_test_assert_instance_of(\KMDG\MenuElements\MenuElementDefinition::class, $registry->getDefinition('column'));
+    menu_elements_test_assert_same(null, $registry->getDefinitionOrNull('missing'));
+
+    $menuItems = $registry->getMenuItems();
+    menu_elements_test_assert_same('column', $menuItems['column']->type);
+    menu_elements_test_assert_same(['menu-elements__column'], $menuItems['column']->classes);
+
+    menu_elements_test_assert_throws(function () use ($registry) {
+        $registry->getTypeLabel('missing');
+    }, \Aesir\v1\Exceptions\AesirException::class, 'Cannot get label for undefined type [missing].');
+};
+
+$tests['field resolver applies stable defaults and normalized values'] = function () {
+    $resolver = new \KMDG\MenuElements\MenuElementFieldResolver();
+
+    $defaultItem = (object) [];
+    menu_elements_test_assert_same(false, $resolver->isLineEnabled($defaultItem));
+    menu_elements_test_assert_same('', $resolver->getColumnSize($defaultItem));
+    menu_elements_test_assert_same(1, $resolver->getSpacerSize($defaultItem));
+
+    $configuredItem = (object) [
+        'enable_line' => '1',
+        'column_size' => 'maximize',
+        'size' => '2.5',
+    ];
+
+    menu_elements_test_assert_same(true, $resolver->isLineEnabled($configuredItem));
+    menu_elements_test_assert_same('maximize', $resolver->getColumnSize($configuredItem));
+    menu_elements_test_assert_same(2.5, $resolver->getSpacerSize($configuredItem));
+
+    $emptyItem = (object) [
+        'enable_line' => '',
+        'size' => '',
+    ];
+
+    menu_elements_test_assert_same(false, $resolver->isLineEnabled($emptyItem));
+    menu_elements_test_assert_same(1, $resolver->getSpacerSize($emptyItem));
+};
+
+$tests['renderer resolves pre-render and markup decisions through the seams'] = function () {
+    $registry = new \KMDG\MenuElements\MenuElementRegistry();
+    $fieldResolver = new \KMDG\MenuElements\MenuElementFieldResolver();
+    $renderer = new \KMDG\MenuElements\MenuElementRenderer($registry, $fieldResolver);
+
+    $registry->registerLegacy('Column', 'column', [$renderer, 'columnCallback'], [$renderer, 'columnCallbackAfter'], [$renderer, 'columnCallbackBefore']);
+    $registry->registerLegacy('Spacer', 'spacer', [$renderer, 'spacerCallback']);
+    $registry->registerLegacy('Title', 'title', [$renderer, 'titleCallback']);
+
+    $column = (object) [
+        'type' => 'column',
+        'classes' => [],
+        'enable_line' => '1',
+        'column_size' => 'maximize',
+    ];
+
+    $column = $renderer->getItemPreRender($column);
+    menu_elements_test_assert_same(['menu-elements__column--maximize'], $column->classes);
+    menu_elements_test_assert_same("<div class='menu-elements__column-wrap menu-elements__column-wrap--line'>", $renderer->getItemContent('', $column, 0, (object) []));
+    menu_elements_test_assert_same('</div>', $renderer->getItemContentAfter('', $column, 0, (object) []));
+
+    $unsafeColumn = (object) [
+        'type' => 'column',
+        'classes' => [],
+        'column_size' => 'ma x!mize',
+    ];
+
+    $unsafeColumn = $renderer->getItemPreRender($unsafeColumn);
+    menu_elements_test_assert_same(['menu-elements__column--maxmize'], $unsafeColumn->classes);
+
+    $spacer = (object) [
+        'type' => 'spacer',
+        'enable_line' => '',
+        'size' => '2',
+    ];
+    $spacerMarkup = $renderer->getItemContent('', $spacer, 0, (object) []);
+    menu_elements_test_assert_contains("class='menu-elements__spacer ", $spacerMarkup);
+    menu_elements_test_assert_contains("padding-top: 1em;margin-bottom: 1em;", $spacerMarkup);
+
+    $title = (object) [
+        'type' => 'title',
+        'title' => '<Section & Title>',
+    ];
+    $titleMarkup = $renderer->getItemContent('', $title, 0, (object) []);
+    menu_elements_test_assert_contains("class='menu-elements__title'", $titleMarkup);
+    menu_elements_test_assert_contains('&lt;Section &amp; Title&gt;', $titleMarkup);
+
+    $unknown = (object) ['type' => 'missing'];
+    menu_elements_test_assert_same('fallback', $renderer->getItemContent('fallback', $unknown, 0, (object) []));
+    menu_elements_test_assert_same('after-fallback', $renderer->getItemContentAfter('after-fallback', $unknown, 0, (object) []));
+    menu_elements_test_assert_same($unknown, $renderer->getItemPreRender($unknown));
+};
+
+$passed = 0;
+$failed = 0;
+
+foreach ($tests as $name => $test) {
+    try {
+        $test();
+        echo "PASS {$name}\n";
+        $passed++;
+    } catch (\Throwable $throwable) {
+        echo "FAIL {$name}\n";
+        echo $throwable->getMessage() . "\n";
+        $failed++;
+    }
+}
+
+echo "\n";
+echo "Assertions: " . $GLOBALS['menu_elements_test_assertions'] . "\n";
+echo "Passed: {$passed}\n";
+echo "Failed: {$failed}\n";
+
+exit($failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

This PR implements issue #12 by adding a minimal pure-PHP seam test harness, making the package scripts truthful, and reducing the Gulp workflow to the Sass-only surface that actually exists in this repo.

## What Changed

- added a small pure-PHP test harness under `tests/`:
  - `tests/bootstrap.php` provides simple assertions plus WordPress shim functions needed by the seam tests
  - `tests/run.php` covers registry resolution, field-resolver defaults, and renderer decisions
- changed `npm test` from an intentional failure to the pure-PHP seam runner
- added `npm run lint:php`, `npm run sass`, `npm run build`, and `npm run watch`
- updated `gulpfile.js` so it only defines Sass-related tasks and no longer advertises dead `src/js/` work
- wired `gulp-sass` to Dart Sass and added `sass` as a dev dependency so the build actually runs
- documented the repo validation path in `docs/maintainer-compatibility.md`

## Why

The repo now has explicit PHP seams worth protecting, but there was no automated proof around them. At the same time, the package and Gulp configuration still described a JavaScript pipeline that does not exist and a build path that did not actually run with the current dependency set.

This change gives the repo a small but real automated baseline and makes the documented commands match what the checkout can actually do today.

## Impact

- `npm test` now provides useful automated coverage instead of failing by design
- the supported Gulp workflow is now Sass-only
- the documented maintenance path is explicit: seam tests, PHP lint, Sass rebuild when needed, then manual WordPress smoke checks
- no WordPress integration harness or front-end redesign was introduced

## Validation

- `npm test`
- `npm run lint:php`
- `npm run build`

Closes #12